### PR TITLE
Add support for multi-line highlights

### DIFF
--- a/whoarder/clippings.py
+++ b/whoarder/clippings.py
@@ -96,13 +96,14 @@ class ClippingsIterator(object):
         count = 1
         while True:
             if count > 5:
-                raise InvalidFormatException('''Input file doesn't seem to be
-                a clippings file, separators are missing or damaged''')
+                print(clipping_buffer[-1])
+                if self._clipping_line1.search( clipping_buffer[-1]) is not None or self._clipping_line2.search(clipping_buffer[-1]) is not None:
+                    raise InvalidFormatException('''Input file doesn't seem to be
+                    a clippings file, separators are missing or damaged''')
             if self.source_file.closed:
                 raise StopIteration
 
             line = self.source_file.readline()
-
             if not line:
                 self.source_file.close()
                 raise StopIteration
@@ -125,7 +126,9 @@ class ClippingsIterator(object):
             line_dict = self._clipping_line1.search(clipping_buffer[0]).groupdict()
             line_dic2 = self._clipping_line2.search(clipping_buffer[1]).groupdict()
             line_dict.update(line_dic2)
-            line_dict['contents'] = clipping_buffer[3]
+            line_dict['contents'] = ""
+            for clipping in clipping_buffer[3:]:
+                line_dict['contents'] += clipping + "\n"
             return line_dict
         except AttributeError:
             print("Failed to import the following note, please report to https://github.com/ronjouch/whoarder :\n  {0}\n".format(clipping_buffer))

--- a/whoarder/clippings.py
+++ b/whoarder/clippings.py
@@ -150,5 +150,5 @@ def _detect_encoding(source):
     return detected_encoding
 
 
-class InvalidFormatException(Exception):
+class InvalidFormatException(BaseException):
     pass

--- a/whoarder/clippings.py
+++ b/whoarder/clippings.py
@@ -96,7 +96,6 @@ class ClippingsIterator(object):
         count = 1
         while True:
             if count > 5:
-                print(clipping_buffer[-1])
                 if self._clipping_line1.search( clipping_buffer[-1]) is not None or self._clipping_line2.search(clipping_buffer[-1]) is not None:
                     raise InvalidFormatException('''Input file doesn't seem to be
                     a clippings file, separators are missing or damaged''')

--- a/whoarder/test/__init__.py
+++ b/whoarder/test/__init__.py
@@ -1,11 +1,13 @@
 from whoarder.clippings import Clippings
 import unittest
+import os
 
 
 class TestImport(unittest.TestCase):
 
     def setUp(self):
-        clippingsimporter = Clippings('test.txt')
+        path = (os.path.dirname(__file__)) + "/test.txt"
+        clippingsimporter = Clippings(path)
         self.clippings = clippingsimporter.clippings
 
     def test_first_clipping(self):
@@ -20,7 +22,7 @@ class TestImport(unittest.TestCase):
         '''
         test.txt should yield a certain number of clippings.
         '''
-        self.assertEqual(len(self.clippings), 17)
+        self.assertEqual(len(self.clippings), 18)
 
     def test_count_notes(self):
         '''
@@ -35,7 +37,7 @@ class TestImport(unittest.TestCase):
         test.txt should yield 13 highlights
         '''
         highlights = [i for i in self.clippings if i['type'] == 'Highlight']
-        self.assertEqual(len(highlights), 13)
+        self.assertEqual(len(highlights), 14)
 
     def test_count_bookmarks(self):
         '''
@@ -87,6 +89,14 @@ class TestImport(unittest.TestCase):
         for clipping in self.clippings:
             self.assertIsNotNone(clipping['contents'])
 
+    def test_multi_line_highlights(self):
+        '''
+        Multiline clippings should be read correctly
+        '''
+
+        contents = """John Doe remarked: \"Man, yeah.\n\nThis is tricky stuff\"\n"""
+        print(self.clippings[-1]['contents'])
+        self.assertEqual(contents, self.clippings[-1]['contents'])
 
 class TestWrongImport(unittest.TestCase):
 

--- a/whoarder/test/__init__.py
+++ b/whoarder/test/__init__.py
@@ -1,4 +1,4 @@
-from whoarder.clippings import Clippings
+from whoarder.clippings import Clippings, InvalidFormatException
 import unittest
 import os
 
@@ -106,6 +106,22 @@ class TestWrongImport(unittest.TestCase):
         '''
         with self.assertRaises(FileNotFoundError):
             self.clippings = Clippings('bar.txt')
+
+
+class TestMulitlineHighlights(unittest.TestCase):
+
+    def setUp(self):
+        self.path = (os.path.dirname(__file__)) + "/failed_test.txt"
+
+    def test_failed_multiline_highlights(self):
+        '''
+        the multiline highlight for failed_test.txt should return an InvalidFormatException
+        
+        '''
+        with self.assertRaises(InvalidFormatException):
+            Clippings(self.path)
+        # self.assertIsNone(None)
+    
 
 if __name__ == '__main__':
     unittest.main()

--- a/whoarder/test/failed_test.txt
+++ b/whoarder/test/failed_test.txt
@@ -1,0 +1,13 @@
+﻿Multiline Failed Highlight (Author 1 Name, Author 1 First Name)
+- Your Highlight on Unnumbered Page | Location 218-219 | Added on Tuesday, April 9, 2013 7:37:21 PM
+
+John Doe remarked: "Man, yeah.
+
+This is tricky stuff"
+﻿Multiline Highlight (Author 1 Name, Author 1 First Name)
+- Your Highlight on Unnumbered Page | Location 218-219 | Added on Tuesday, April 9, 2013 7:37:21 PM
+
+John Doe remarked: "Man, yeah.
+
+This is tricky stuff"
+==========

--- a/whoarder/test/test.txt
+++ b/whoarder/test/test.txt
@@ -90,6 +90,19 @@ John Doe remarked: "Man, yeah.
 
 This is tricky stuff"
 ==========
+﻿Multiline Failed Highlight (Author 1 Name, Author 1 First Name)
+- Your Highlight on Unnumbered Page | Location 218-219 | Added on Tuesday, April 9, 2013 7:37:21 PM
+
+John Doe remarked: "Man, yeah.
+
+This is tricky stuff"
+﻿Multiline Highlight (Author 1 Name, Author 1 First Name)
+- Your Highlight on Unnumbered Page | Location 218-219 | Added on Tuesday, April 9, 2013 7:37:21 PM
+
+John Doe remarked: "Man, yeah.
+
+This is tricky stuff"
+==========
 Bogus Highlight
 nonsense
 

--- a/whoarder/test/test.txt
+++ b/whoarder/test/test.txt
@@ -90,19 +90,6 @@ John Doe remarked: "Man, yeah.
 
 This is tricky stuff"
 ==========
-﻿Multiline Failed Highlight (Author 1 Name, Author 1 First Name)
-- Your Highlight on Unnumbered Page | Location 218-219 | Added on Tuesday, April 9, 2013 7:37:21 PM
-
-John Doe remarked: "Man, yeah.
-
-This is tricky stuff"
-﻿Multiline Highlight (Author 1 Name, Author 1 First Name)
-- Your Highlight on Unnumbered Page | Location 218-219 | Added on Tuesday, April 9, 2013 7:37:21 PM
-
-John Doe remarked: "Man, yeah.
-
-This is tricky stuff"
-==========
 Bogus Highlight
 nonsense
 

--- a/whoarder/test/test.txt
+++ b/whoarder/test/test.txt
@@ -83,6 +83,13 @@ Slouka talking about understanding and shaping and understanding and shaping and
 
 Slouka quoting Thoreau about margins to life and space and silence and the forming of self and space and silence and the forming of self and space and silence and the forming of self.
 ==========
+﻿Multiline Highlight (Author 1 Name, Author 1 First Name)
+- Your Highlight on Unnumbered Page | Location 218-219 | Added on Tuesday, April 9, 2013 7:37:21 PM
+
+John Doe remarked: "Man, yeah.
+
+This is tricky stuff"
+==========
 Bogus Highlight
 nonsense
 


### PR DESCRIPTION
Previously, on parsing a multi line highlight, the parser returned an InvalidFormatException. 

With this PR, I aim to fix this by allowing multi line highlights, as long as it does not share the format of the Book/Author line or the Location line.