### PR TITLE
Fix a number of parsing issues found in the wild

### DIFF
--- a/whoarder/clippings.py
+++ b/whoarder/clippings.py
@@ -80,7 +80,7 @@ class ClippingsIterator(object):
     _clipping_line2 = re.compile(r'''
         ^-\ Your\ (?P<type>\w*)                         # Your Highlight
         \ (?:on\ )?(?P<page>Unnumbered\ Page|Page\ .*)  #  on Page 42
-        \ \|\ (?:on\ )?Location\ (?P<location>.*)       #  | Location 123-321
+        \ \|\ (?:on\ |at\ )?Location\ (?P<location>.*)  #  | Location 123-321
         \ \|\ Added\ on\ (?P<date>.*)$                  #  | Added on...
         ''', re.VERBOSE | re.IGNORECASE)
 

--- a/whoarder/clippings.py
+++ b/whoarder/clippings.py
@@ -75,7 +75,7 @@ class ClippingsIterator(object):
     _clipping_separator = '==========\n'
     _clipping_line1 = re.compile(r'''
         ^(?P<book>.*?)                           # Le Petit Prince
-        (\ \((?P<author>.*)\))?$                 #  (De Saint-Exupery, Antoine)
+        (\ \((?P<author>[^()]*)\))?$             #  (De Saint-Exupery, Antoine)
         ''', re.VERBOSE | re.IGNORECASE)
     _clipping_line2 = re.compile(r'''
         ^-\ (?:Your\ )?(?P<type>\w*)                         # Your Highlight

--- a/whoarder/clippings.py
+++ b/whoarder/clippings.py
@@ -74,14 +74,15 @@ class ClippingsIterator(object):
 
     _clipping_separator = '==========\n'
     _clipping_line1 = re.compile(r'''
-        ^(?P<book>.*)                            # Le Petit Prince
-        \ \((?P<author>.*)\)$                    #  (De Saint-Exupery, Antoine)
+        ^(?P<book>.*?)                           # Le Petit Prince
+        (\ \((?P<author>.*)\))?$                 #  (De Saint-Exupery, Antoine)
         ''', re.VERBOSE | re.IGNORECASE)
     _clipping_line2 = re.compile(r'''
-        ^-\ Your\ (?P<type>\w*)                         # Your Highlight
-        \ (?:on\ )?(?P<page>Unnumbered\ Page|Page\ .*)  #  on Page 42
-        \ \|\ (?:on\ |at\ )?Location\ (?P<location>.*)  #  | Location 123-321
-        \ \|\ Added\ on\ (?P<date>.*)$                  #  | Added on...
+        ^-\ Your\ (?P<type>\w*)                          # Your Highlight
+        (\ (?:on\ )?(?P<page>Unnumbered\ Page|Page\ .*)  #  on Page 42 |
+        \ \|)?
+        \ (?:on\ |at\ )?Location\ (?P<location>.*)       #  Location 123-321
+        \ \|\ Added\ on\ (?P<date>.*)$                   #  | Added on...
         ''', re.VERBOSE | re.IGNORECASE)
 
     def __init__(self, source):
@@ -96,9 +97,26 @@ class ClippingsIterator(object):
         count = 1
         while True:
             if count > 5:
-                if self._clipping_line1.search( clipping_buffer[-1]) is not None or self._clipping_line2.search(clipping_buffer[-1]) is not None:
-                    raise InvalidFormatException('''Input file doesn't seem to be
-                    a clippings file, separators are missing or damaged''')
+                line_dict = self._clipping_line1.search(clipping_buffer[0])
+                line_dic2 = self._clipping_line2.search(clipping_buffer[1])
+                hl_type = None
+                if line_dic2:
+                    hl_type = line_dic2.groupdict()['type']
+
+                if not line_dict or not line_dic2 or hl_type not in ('Note', 'Highlight'):
+                    raise InvalidFormatException(
+                        '''Input file doesn't seem to be
+                        a clippings file, got invalid header lines'''
+                    )
+
+                # Check for corruption - if the current line is a valid first
+                # line, then the content somehow got merged together.
+                if self._clipping_line1.search(clipping_buffer[-2]) and self._clipping_line2.search(clipping_buffer[-1]):
+                    raise InvalidFormatException(
+                        '''Input file doesn't seem to be
+                        a clippings file, separators are missing or damaged'''
+                    )
+
             if self.source_file.closed:
                 raise StopIteration
 
@@ -125,9 +143,7 @@ class ClippingsIterator(object):
             line_dict = self._clipping_line1.search(clipping_buffer[0]).groupdict()
             line_dic2 = self._clipping_line2.search(clipping_buffer[1]).groupdict()
             line_dict.update(line_dic2)
-            line_dict['contents'] = ""
-            for clipping in clipping_buffer[3:]:
-                line_dict['contents'] += clipping + "\n"
+            line_dict['contents'] = '\n'.join(clipping_buffer[3:]).strip()
             return line_dict
         except AttributeError:
             print("Failed to import the following note, please report to https://github.com/ronjouch/whoarder :\n  {0}\n".format(clipping_buffer))

--- a/whoarder/clippings.py
+++ b/whoarder/clippings.py
@@ -78,11 +78,12 @@ class ClippingsIterator(object):
         (\ \((?P<author>.*)\))?$                 #  (De Saint-Exupery, Antoine)
         ''', re.VERBOSE | re.IGNORECASE)
     _clipping_line2 = re.compile(r'''
-        ^-\ Your\ (?P<type>\w*)                          # Your Highlight
-        (\ (?:on\ )?(?P<page>Unnumbered\ Page|Page\ .*)  #  on Page 42 |
+        ^-\ (?:Your\ )?(?P<type>\w*)                         # Your Highlight
+        (\ (?:on\ )?(?P<page>Unnumbered\ Page|Page\ .*)      #  on Page 42 |
         \ \|)?
-        \ (?:on\ |at\ )?Location\ (?P<location>.*)       #  Location 123-321
-        \ \|\ Added\ on\ (?P<date>.*)$                   #  | Added on...
+        (?:\ This\ Article)?                                 #  This Article
+        \ (?:on\ |at\ )?(Location|Loc\.)\ (?P<location>.*)   #  Location 123-321
+        \ \|\ Added\ on\ (?P<date>.*)$                       #  | Added on...
         ''', re.VERBOSE | re.IGNORECASE)
 
     def __init__(self, source):

--- a/whoarder/templates/template1.html
+++ b/whoarder/templates/template1.html
@@ -23,6 +23,10 @@
             .group {font-size: 20px; font-weight: bold; color: #161; border-bottom: 1px solid #116611; padding-top: 15px;}
             .right {float: right; font-weight: normal; color: #333;}
             /*.hidden_author {display: none;}*/
+
+            li[type=Note] {
+                background: #FADC7A;
+            }
         </style>
         <script type="text/javascript" language="javascript">
         /*! jQuery v1.11.1 | (c) 2005, 2014 jQuery Foundation, Inc. | jquery.org/license */
@@ -84,8 +88,12 @@
             </li>
             {% endfor %}
 			{% for c in clippings %}
-			  <li level="2" author="{{ c.author }}" book="{{ c.book }}">
-			    <span class="contents">{{ c.contents }}</span><br />
+              <li level="2" author="{{ c.author }}" book="{{ c.book }}" type="{{ c.type }}">
+                <span class="contents">
+                    {% autoescape false %}
+                        {{ c.contents | escape | replace("\n", "<br>") }}
+                    {% endautoescape %}
+                </span><br />
 			    <span class="metadata">
 			      <span class="author">{{ c.author }}</span>
 			      , <span class="book">{{ c.book }}</span>.

--- a/whoarder/test/__init__.py
+++ b/whoarder/test/__init__.py
@@ -22,7 +22,7 @@ class TestImport(unittest.TestCase):
         '''
         test.txt should yield a certain number of clippings.
         '''
-        self.assertEqual(len(self.clippings), 19)
+        self.assertEqual(len(self.clippings), 21)
 
     def test_count_notes(self):
         '''
@@ -30,14 +30,14 @@ class TestImport(unittest.TestCase):
         '''
         print(self.clippings)
         notes = [i for i in self.clippings if i['type'] == 'Note']
-        self.assertEqual(len(notes), 1)
+        self.assertEqual(len(notes), 2)
 
     def test_count_highlights(self):
         '''
         test.txt should yield 14 highlights
         '''
         highlights = [i for i in self.clippings if i['type'] == 'Highlight']
-        self.assertEqual(len(highlights), 15)
+        self.assertEqual(len(highlights), 16)
 
     def test_count_bookmarks(self):
         '''
@@ -64,9 +64,14 @@ class TestImport(unittest.TestCase):
     def test_presence_author(self):
         '''
         Each clipping should reference its author's name.
+
+        One exception: book `How to Win Friends and Influence People`
         '''
         for clipping in self.clippings:
-            self.assertIsNotNone(clipping['author'])
+            if clipping['book'] != 'How to Win Friends and Influence People':
+                self.assertIsNotNone(clipping['author'])
+            else:
+                self.assertIsNone(clipping['author'])
 
     def test_presence_location(self):
         '''
@@ -94,10 +99,19 @@ class TestImport(unittest.TestCase):
         Multiline clippings should be read correctly
         '''
 
-        contents = """John Doe remarked: \"Man, yeah.\n\nThis is tricky stuff\"\n"""
+        contents = """John Doe remarked: \"Man, yeah.\n\nThis is tricky stuff\""""
         clipping = self.clippings[17]
         print(clipping['contents'])
         self.assertEqual(contents, clipping['contents'])
+
+    def test_multiline_note(self):
+        '''
+        Multi-line note should be correctly extracted.
+        '''
+        notes = [i for i in self.clippings if i['type'] == 'Note']
+        notes = [i for i in notes if i['book'] == 'The Story of Britain: From the Romans to the Present: A Narrative History']
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0]['contents'], "Idea: explore these concepts\nin further detail")
 
 
 class TestWrongImport(unittest.TestCase):
@@ -118,12 +132,11 @@ class TestMulitlineHighlights(unittest.TestCase):
     def test_failed_multiline_highlights(self):
         '''
         the multiline highlight for failed_test.txt should return an InvalidFormatException
-        
         '''
         with self.assertRaises(InvalidFormatException):
             Clippings(self.path)
         # self.assertIsNone(None)
-    
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/whoarder/test/__init__.py
+++ b/whoarder/test/__init__.py
@@ -22,7 +22,7 @@ class TestImport(unittest.TestCase):
         '''
         test.txt should yield a certain number of clippings.
         '''
-        self.assertEqual(len(self.clippings), 18)
+        self.assertEqual(len(self.clippings), 19)
 
     def test_count_notes(self):
         '''
@@ -34,10 +34,10 @@ class TestImport(unittest.TestCase):
 
     def test_count_highlights(self):
         '''
-        test.txt should yield 13 highlights
+        test.txt should yield 14 highlights
         '''
         highlights = [i for i in self.clippings if i['type'] == 'Highlight']
-        self.assertEqual(len(highlights), 14)
+        self.assertEqual(len(highlights), 15)
 
     def test_count_bookmarks(self):
         '''
@@ -95,8 +95,10 @@ class TestImport(unittest.TestCase):
         '''
 
         contents = """John Doe remarked: \"Man, yeah.\n\nThis is tricky stuff\"\n"""
-        print(self.clippings[-1]['contents'])
-        self.assertEqual(contents, self.clippings[-1]['contents'])
+        clipping = self.clippings[17]
+        print(clipping['contents'])
+        self.assertEqual(contents, clipping['contents'])
+
 
 class TestWrongImport(unittest.TestCase):
 

--- a/whoarder/test/__init__.py
+++ b/whoarder/test/__init__.py
@@ -22,7 +22,7 @@ class TestImport(unittest.TestCase):
         '''
         test.txt should yield a certain number of clippings.
         '''
-        self.assertEqual(len(self.clippings), 21)
+        self.assertEqual(len(self.clippings), 22)
 
     def test_count_notes(self):
         '''
@@ -34,10 +34,10 @@ class TestImport(unittest.TestCase):
 
     def test_count_highlights(self):
         '''
-        test.txt should yield 14 highlights
+        test.txt should yield 15 highlights
         '''
         highlights = [i for i in self.clippings if i['type'] == 'Highlight']
-        self.assertEqual(len(highlights), 16)
+        self.assertEqual(len(highlights), 17)
 
     def test_count_bookmarks(self):
         '''
@@ -112,6 +112,17 @@ class TestImport(unittest.TestCase):
         notes = [i for i in notes if i['book'] == 'The Story of Britain: From the Romans to the Present: A Narrative History']
         self.assertEqual(len(notes), 1)
         self.assertEqual(notes[0]['contents'], "Idea: explore these concepts\nin further detail")
+
+    def test_paranethsis_in_book_name(self):
+        '''
+        Book names can contain parentheses.
+        '''
+        highlights = [i for i in self.clippings if 'Refactoring' in i['book']]
+        self.assertEqual(len(highlights), 1)
+        self.assertEqual(
+            highlights[0]['book'],
+            "Refactoring: Improving the Design of Existing Code, Second Edition (John Smith's Library)")
+        self.assertEqual(highlights[0]['author'], "Martin Fowler")
 
 
 class TestWrongImport(unittest.TestCase):

--- a/whoarder/test/test.txt
+++ b/whoarder/test/test.txt
@@ -112,3 +112,8 @@ Idea: explore these concepts
 in further detail
 
 ==========
+Refactoring: Improving the Design of Existing Code, Second Edition (John Smith's Library) (Martin Fowler)
+- Your Highlight at location 7400-7402 | Added on Thursday, 18 February 2021 05:28:18
+
+Like most tricky decisions, it’s not something I can reliably get right, so it’s important that I can reliably change things so the program can take advantage of my increasing understanding.
+==========

--- a/whoarder/test/test.txt
+++ b/whoarder/test/test.txt
@@ -100,3 +100,15 @@ nonsense
 
 This Highlight should fail to import and log an error message
 ==========
+How to Win Friends and Influence People
+- Your Highlight on page xvi | location 278-280 | Added on Sunday, 17 May 2020 19:35:38
+
+even in such technical lines as engineering, about 15 per cent of one’s financial success is due to one’s technical knowledge and about 85 per cent is due to skill in human engineering – to personality and the ability to lead people.
+==========
+The Story of Britain: From the Romans to the Present: A Narrative History (Fraser, Rebecca)
+- Your Note at location 1638 | Added on Wednesday, 10 June 2020 06:03:51
+
+Idea: explore these concepts
+in further detail
+
+==========

--- a/whoarder/test/test.txt
+++ b/whoarder/test/test.txt
@@ -90,6 +90,11 @@ John Doe remarked: "Man, yeah.
 
 This is tricky stuff"
 ==========
+... trotzdem Ja zum Leben sagen: Ein Psychologe erlebt das Konzentrationslager (Viktor E. Frankl)
+- Your Highlight at location 146-149 | Added on Thursday, 16 July 2020 06:12:24
+
+Oft genug waren die Capos »schärfer« als die Lagerwache und stellten die ärgeren Peiniger der gewöhnlichen Häftlinge, schlugen z.B. manchmal viel mehr auf sie ein als selbst die SS. Wurden doch von vornherein im allgemeinen nur solche Häftlinge zu Capos gemacht, die zu derartigem Vorgehen eben taugten, bzw. sofort abgesetzt, sobald sie in diesem Sinne nicht »mittaten«.
+==========
 Bogus Highlight
 nonsense
 


### PR DESCRIPTION
This fixes issues I found in my own Kindle file:

* Books don't always have an author
* Book names can have parenthesis
* Multi-line notes (I had developed this independently of Monish's changes, which are now incorporated here by way of rebasing)

This also includes a fix for the HTML output to escape the content and thus avoid issues with HTML tags seeping into content.